### PR TITLE
Add generics for EventEmitter

### DIFF
--- a/decorators/event_emitter.ts
+++ b/decorators/event_emitter.ts
@@ -1,11 +1,11 @@
-export class EventEmitter {
-    private listeners: Array<Function> = [];
+export class EventEmitter<T extends any = any> {
+    private listeners: Array<(arg: T) => void> = [];
 
-    emit(event: any = null) {
+    emit(event: T | null = null) {
         this.listeners.forEach(callback => callback.call(null, event));
     }
 
-    subscribe(callback: Function) {
+    subscribe(callback: (arg: T) => void) {
         this.listeners.push(callback);
     }
 }

--- a/decorators/event_emitter.ts
+++ b/decorators/event_emitter.ts
@@ -1,7 +1,7 @@
 export class EventEmitter<T extends any = any> {
     private listeners: Array<(event: T) => void> = [];
 
-    emit(event: T | null = null) {
+    emit(event?: T) {
         this.listeners.forEach(callback => callback.call(null, event));
     }
 

--- a/decorators/event_emitter.ts
+++ b/decorators/event_emitter.ts
@@ -1,11 +1,11 @@
 export class EventEmitter<T extends any = any> {
-    private listeners: Array<(arg: T) => void> = [];
+    private listeners: Array<(event: T) => void> = [];
 
     emit(event: T | null = null) {
         this.listeners.forEach(callback => callback.call(null, event));
     }
 
-    subscribe(callback: (arg: T) => void) {
+    subscribe(callback: (event: T) => void) {
         this.listeners.push(callback);
     }
 }


### PR DESCRIPTION
Improvement mentioned in https://github.com/fluix/ng1-shift/issues/105
Used `any` as default type for generic, but now it will be available to typecheck EventEmitter calls