### PR TITLE
Issue 112: Fix incompatibility Angular 12 and ngUpgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng1-shift",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Angular 1.5+ decorators for writing Angular2 like.",
   "files": [
     "dist"

--- a/src/decorators/component/index.ts
+++ b/src/decorators/component/index.ts
@@ -2,7 +2,13 @@ import {DeclarationType} from "../../models/declaration-type";
 import {Metakeys} from "../../models/metakeys";
 import {replaceTwoWayBindings} from "./helpers";
 
-export function Component(config?: {selector?: string, template?: string}): ClassDecorator {
+interface ComponentConfig {
+    selector?: string;
+    template?: string;
+    styles?: Array<any>; // added for compatibility with Angular12 with ngUpgrade
+}
+
+export function Component(config?: ComponentConfig): ClassDecorator {
     return function (target: any) {
         if (config) {
             if (config.template) {


### PR DESCRIPTION
For some reason, during compile with ngUpgrade and Angular 12, compiler thinks about `@Component` as Angular `@Component` and requires styles there.
Another option would be renaming ng1-shift `@Component` to something else, but it's breaking change.
